### PR TITLE
Refactor everything

### DIFF
--- a/ob-shstream.el
+++ b/ob-shstream.el
@@ -1,11 +1,11 @@
-;;; ob-shstream.el --- org-babel functions for simple async shell eval
+;;; ob-shstream.el --- org-babel functions for simple async shell eval -*- lexical-binding: t -*-
 
-;; Copyright (C) your name here
+;; Copyright (C) 2021 Excalamus (excalamus.com), whacked
+;; (https://github.com/whacked)
 
-;; Author: your name here
+;; Author: Excalamus, whacked (https://github.com/whacked)
 ;; Keywords: literate programming, reproducible research
-;; Homepage: http://orgmode.org
-;; Version: 0.01
+;; Version: 0.02
 
 ;;; License:
 
@@ -26,229 +26,165 @@
 
 ;;; Commentary:
 
-;; the default ob-sh evaluation for shell scripts in org-mode is
-;; blocking, so commands like e.g.
-;; 
+;; The default ob-sh evaluation for shell scripts in org-mode is
+;; blocking, so commands like the following freeze Emacs:
+;;
 ;; #+BEGIN_SRC sh
 ;; ping -c 5 127.0.0.1
 ;; #+END_SRC
 ;;
-;; will block when run, and results only become visible when the
-;; process terminates. :session may be able to hand this, but it
-;; doesn't currently work for me OOTB. ob-shstream is a simple
-;; workaround.
-;; 
-;; It returns a process buffer name immediately on eval, saves the
-;; eval contents to a shell script in `org-babel-temporary-directory`
-;; and executes it with `bash`. org-babel thus outputs the unfinished
-;; process buffer name as the result, and the process buffer is shown
-;; with output asynchronously appended. When the process terminates,
-;; the output replaces the unfinished process name result as the final
-;; org-babel #+RESULTS section.
+;; Results only become visible when the process terminates.
 ;;
-;; NOTE: header arguments (e.g. session) are not supported
-;; 
-;; async update procedure modified from http://www.drieu.org/code/sources/tail.el
-;; also see:
-;; http://orgmode.org/w/worg.git/blob/HEAD:/org-contrib/babel/ob-template.el
-;; http://orgmode.org/w/?p=org-mode.git;a=blob_plain;f=lisp/ob-eval.el
+;; ob-shstream.el works by running the source given in a shell block
+;; in a separate process. It does this by creating a temporary file
+;; and executing it. Output is appended to a buffer and a hash
+;; representing the source code acts as the result until the process
+;; finishes. When completed, the hash is replaced with the output
+;; buffer contents.
+;;
+;; NOTE: header arguments (e.g. :session) are not supported and some
+;; may not work as expected (e.g. :table). This was only tested with
+;; :result output. This is because the org-babel functionality is
+;; largely undocumented and it's API inconsistent.
 
 ;;; Usage:
 
-;; load this file and update org-babel settings:
+;; Load this file and update the org-babel settings:
+;;
 ;; (org-babel-do-load-languages
 ;;  'org-babel-load-languages
 ;;  '(...
 ;;    (shstream . t)
 ;;    ...))
-;; then use like a normal sh block, but replace "sh" with "shstream"
+;;
+;; then use like a normal sh block, but replace "sh" with "shstream".
+;;
+;; Example:
+;;
+;;     #+begin_src shstream :results output
+;;     echo "hello, world!"
+;;     sleep 2
+;;     echo "goodbye, cruel world..."
+;;     #+end_src
+;;
+;; Check the source code for user variables.
 
 ;;; Requirements:
 
-;; defaults to evaluation using `bash`
-
 ;;; Code:
-(require 'ob)
-(require 'ob-ref)
-(require 'ob-comint)
-(require 'ob-eval)
-;; possibly require modes required for your language
 
-(defvar org-babel-shstream-command "bash"
-  "Name of command for executing shstream code.")
+(defvar ob-shstream-shell-command "bash"
+  "Command used to execute code within a shstream block.
 
-;; optionally declare default header arguments for this language
-(defvar org-babel-default-header-args:shstream '())
+It is assumed that the command is on the shell path (i.e. that it
+can be called from the shell without providing the path to the
+executable).")
 
-;; This function expands the body of a source code block by doing
-;; things like prepending argument definitions to the body, it should
-;; be called by the `org-babel-execute:shstream' function below.
-(defun org-babel-expand-body:shstream (body params &optional processed-params)
-  "Expand BODY according to PARAMS, return the expanded body."
-  (let ((vars (nth 1 (or processed-params (org-babel-process-params params)))))
-    ; do nothing now
-    )
-  )
+(defun ob-shstream-default-insertion-filter (proc string)
+  "Insert process output in process buffer.
 
+Taken from (elisp) Filter Functions."
+  (when (buffer-live-p (process-buffer proc))
+    (display-buffer (process-buffer proc))
+    (with-current-buffer (process-buffer proc)
+      (let ((inhibit-read-only t))
+        (save-excursion
+          ;; Insert the text, advancing the process marker.
+          (goto-char (process-mark proc))
+          (insert string)
+          (set-marker (process-mark proc) (point)))))))
 
+(defvar ob-shstream-filter-function 'ob-shstream-default-insertion-filter
+  "Filter function to apply to process output before it is
+inserted into the process output buffer.")
 
-;; this section largely follows http://www.drieu.org/code/sources/tail.el
-(defun shstream-disp-window (shstream-buffer shstream-msg)
-  "Display some content specified by ``tail-msg'' inside buffer
-``tail-msg''.  Create this buffer if necessary and put it inside a
-newly created window on the lowest side of the frame."
+(defun org-babel-execute:shstream-pass-through (body params)
+  "Execute a block of shstream-pass-through code with org-babel.
 
-  (require 'electric)
+This function is called by `org-babel-execute-src-block' This
+particular definition is a dummy source language used strictly to
+format shstream output."
+  body)
 
-  ;; Make sure we're not in the minibuffer
-  ;; before splitting the window.
-
-  (if (equal (selected-window) (minibuffer-window))
-      (if (other-window 1) 
-          (select-window (other-window 1))
-        (if (and window-system (other-frame 1))
-            (select-frame (other-frame 1)))))
-  
-  (let* ((this-buffer (current-buffer))
-         (this-window (selected-window))
-         (shstream-disp-buf (set-buffer (get-buffer-create shstream-buffer))))
-
-    (if (cdr (assq 'unsplittable (frame-parameters)))
-        ;; In an unsplittable frame, use something somewhere else.
-        (display-buffer shstream-disp-buf)
-      (unless (or (special-display-p (buffer-name shstream-disp-buf))
-                  (same-window-p (buffer-name shstream-disp-buf))
-                  (get-buffer-window shstream-buffer))
-        
-        ;; this conflicts with pop-to-buffer induced splitting below
-        ;; ;; create a window split from available screen estate
-        ;; ;; NOTE width:height is NOT 1:1
-        ;; ;; since chars are not as wide as tall.
-        ;; ;; but also, horizontal space is worth more than vertical space,
-        ;; ;; so adjust with a weighting that (still) favors horizontal.
-        ;; ;; in actual practice, haven't noticed it really mattering from 1.
-        ;; (let ((W (window-width))
-        ;;       (H (window-height)))
-        ;;   (message "%s x %s" W H)
-        ;;   (if (< (* 1.25 H) W)
-        ;;       (split-window-horizontally)
-        ;;     (split-window-vertically)))
-        )
-      (pop-to-buffer shstream-disp-buf))
-
-    (toggle-read-only 0)
-    (insert shstream-msg)
-    (toggle-read-only 1)
-    (set-buffer-modified-p nil)
-    (select-window this-window)
-    ))
-
-(defun shstream-filter (process line)
-  "Tail filter called when some output comes."
-  (shstream-disp-window (process-buffer process) line))
-
-
-
-;; This is the main function which is called to evaluate a code
-;; block.
-;;
-;; This function will evaluate the body of the source code and
-;; return the results as emacs-lisp depending on the value of the
-;; :results header argument
-;; - output means that the output to STDOUT will be captured and
-;;   returned
-;; - value means that the value of the last statement in the
-;;   source code block will be returned
-;;
-;; The most common first step in this function is the expansion of the
-;; PARAMS argument using `org-babel-process-params'.
-;;
-;; Please feel free to not implement options which aren't appropriate
-;; for your language (e.g. not all languages support interactive
-;; "session" evaluation).  Also you are free to define any new header
-;; arguments which you feel may be useful -- all header arguments
-;; specified by the user will be available in the PARAMS variable.
 (defun org-babel-execute:shstream (body params)
-  "Execute a block of sh code with org-babel.  This function is
-called by `org-babel-execute-src-block'"
-  (message "executing shstream source code block")
-  (let* ((processed-params (org-babel-process-params params))
-         ;; set the session if the session variable is non-nil
-         ;; (session (org-babel-shstream-initiate-session (first processed-params)))
-         ;; variables assigned for use in the block
-         (vars (second processed-params))
-         (result-params (third processed-params))
-         ;; either OUTPUT or VALUE which should behave as described above
-         (result-type (fourth processed-params))
-         ;; expand the body with `org-babel-expand-body:shstream'
-         (full-body (org-babel-expand-body:shstream
-                     body params processed-params)))
-    ;; actually execute the source-code block either in a session or
-    ;; possibly by dropping it to a temporary file and evaluating the
-    ;; file.
-    ;; 
-    ;; for session based evaluation the functions defined in
-    ;; `org-babel-comint' will probably be helpful.
-    ;;
-    ;; for external evaluation the functions defined in
-    ;; `org-babel-eval' will probably be helpful.
-    ;;
-    ;; when forming a shell command, or a fragment of code in some
-    ;; other language, please preprocess any file names involved with
-    ;; the function `org-babel-process-file-name'. (See the way that
-    ;; function is used in the language files)
+  "Execute a block of shstream code with org-babel.
 
-    ;; eval content
-    (lexical-let* ((hash-string (secure-hash 'md5 body))
-                   (process-buffer-name (concat "*emacs-process-" hash-string "-<waiting>*"))
-                   (tempfile-path (concat org-babel-temporary-directory "/process-" hash-string ".sh")))
+This function is called by `org-babel-execute-src-block'"
+  (let* ((org-buffer (current-buffer))
+         (hash (secure-hash 'sha256 body))
+         (hash-name (concat "ob-shstream-" hash))
+         (short-hash-name (concat "ob-shstream-" (substring hash 0 7)))
+         (process-output-buffer-name (concat "*" short-hash-name "*"))
+         (temp-shell-file (org-babel-temp-file hash-name ".sh"))
+         ;; (info (org-babel-get-src-block-info))
+         (results-params (cdr (assq :results params)))
+         (session-name (cdr (assq :session params))))
 
-      ;; (insert (format "\n#+RESULTS:\n: %s\n" process-buffer-name))
-      (write-region (concat "\n" body "\n") nil tempfile-path 'append)
+    ;; shell source must be in a temp file to be run asynchronously
+    (with-temp-file temp-shell-file
+      (insert body))
 
-      (let ((process 
-             (apply 'start-process-shell-command
-                    (concat "shstream-" hash-string)
-                    process-buffer-name
-                    org-babel-shstream-command
-                    (list tempfile-path))))     
-        
-        (set-process-filter process 'shstream-filter)
-        
-        (set-process-sentinel
-         process
-         (lambda (p e)
-           (let ((buffer (process-buffer p)))
-             (when (not (null buffer))
-               ;; (message process-buffer-name)
-               (save-excursion
-                 (beginning-of-buffer)
-                 ;; initially used this:
-                 ;; (replace-string
-                 ;;  (concat ": " process-buffer-name) ...)
-                 ;; which should work, but to be extra sure
-                 ;; we'll use a match-all from beginning-of-line
-                 (when (re-search-forward
-                        (concat "^.*"
-                                ;; escape the earmuffs
-                                (replace-regexp-in-string "\\*" "\\\\*" process-buffer-name)
-                                "$") nil t)
-                   (replace-match
-                    (concat "#+begin_example\n"
-                            (with-current-buffer (get-buffer process-buffer-name)
-                              (replace-regexp-in-string
-                               ""
-                               "\n" (buffer-string) nil 'literal))
-                            "\n#+end_example\n")))
-                 )
-               (delete-window (get-buffer-window process-buffer-name))
-               (kill-buffer process-buffer-name)
-               (delete-file tempfile-path)))))
-        ;; process ;; return process directly (for debug)
-        process-buffer-name
-        )
-      )
-    ))
+    (with-current-buffer (get-buffer-create process-output-buffer-name)
+      (display-buffer process-output-buffer-name)
+      (read-only-mode nil))
+
+    (let* ((process (make-process
+                     :name hash-name
+                     :buffer process-output-buffer-name
+                     :command (list ob-shstream-shell-command temp-shell-file)
+                     ;; no need to communicate between processes; kill
+                     ;; with list-processes if needed
+                     :connection 'pipe
+                     :filter ob-shstream-filter-function
+                     :sentinel `(lambda (process event)
+                                  (if (string= event "finished\n")
+                                      (progn
+
+                                        ;; run process output through shstream-pass-through in order to format
+                                        ;; (e.g. put colons in front of each line)
+                                        (let ((formatted-result
+                                               (with-temp-buffer
+                                                 ;; DEBUG:
+                                                 ;; (with-current-buffer (get-buffer-create "*shstream-pass-through*")
+                                                 ;;   (erase-buffer)
+                                                 (insert (format "#+begin_src shstream-pass-through :results %s :session %s\n%s#+end_src"
+                                                                 ,results-params
+                                                                 ,session-name
+                                                                 (with-current-buffer ,process-output-buffer-name
+                                                                   (buffer-string))))
+                                                 (org-babel-execute-src-block)
+                                                 ;; get the org formatted result
+                                                 (let ((result-start (+ (org-babel-where-is-src-block-result) 10)))
+                                                   (buffer-substring-no-properties result-start (point-max))))))
+
+                                          ;; replace hash with formatted results
+                                          (save-excursion
+                                            (save-restriction
+                                              (with-current-buffer ,org-buffer
+                                                (widen)
+                                                (beginning-of-buffer)
+                                                (re-search-forward ,hash nil t)
+                                                ;; assumes no one has put any text between the results
+                                                ;; and the source block which contains "shstream"
+                                                (goto-char (re-search-backward "shstream" nil t))
+
+                                                (let* ((results-start (+ (org-babel-where-is-src-block-result) 10))
+                                                       (results-end (when results-start
+                                                                      (save-excursion
+                                                                        (goto-char results-start)
+                                                                        (goto-char (org-babel-result-end))
+                                                                        (point)))))
+                                                  (delete-region results-start results-end)
+                                                  (goto-char results-start)
+                                                  (insert formatted-result)
+                                                  ;; this is probably annoying, but that's Emacs window/buffer
+                                                  ;; management for ya
+                                                  (switch-to-prev-buffer (get-buffer-window ,process-output-buffer-name) t)
+                                                  (kill-buffer ,process-output-buffer-name)
+                                                  (delete-file ,temp-shell-file)))))))))))))
+
+    ;; use hash as place holder until process completes
+    hash))
 
 (provide 'ob-shstream)
 ;;; ob-shstream.el ends here


### PR DESCRIPTION
When I tried using the package, it didn't work out of the
box (probably bit-rot). Its ideas, however, were solid. Thanks for sharing it.  

I cleaned things up and in the process basically refactored everything. I might take another stab at it and try to get sessions to work, as well as parameter passing.  I see from https://github.com/whacked/ob-shstream/issues/2 that the package is no longer maintained. I don't blame you. I don't really want to maintain it, but I am happy to host it as the "main" repo. Thoughts?

As for what's different, some great efforts are taken to format the results so that they match
typical Org results. All the source evaluation functions Org
provides (that I could find and understand) return a plain string. But
results are not presented to users as plain strings. Instead they are
prefixed with colons, formatted as a table, et cetera. To cope with
this (and my limited time and patience), I pass the plain text results
through a dummy source block in hopes that it will format the results
correctly (it doesn't always) and copy that output.  The output formatting is
correct for the ":results output" header, but not for all headers,
such as ":results table". This might be fixed by figuring out how to pass
parameters and info arguments within elisp calls to the org execute
related functions.  This commit, like previous versions, cannot work
with sessions.